### PR TITLE
feat(ui): add contextual menu interactions in project board

### DIFF
--- a/apps/ui/src/components/ContextMenu.tsx
+++ b/apps/ui/src/components/ContextMenu.tsx
@@ -1,0 +1,50 @@
+export type ContextMenuAction = {
+  id: string
+  label: string
+  danger?: boolean
+  onSelect: () => void
+}
+
+type ContextMenuProps = {
+  x: number
+  y: number
+  actions: ContextMenuAction[]
+  onClose: () => void
+}
+
+export function ContextMenu({ x, y, actions, onClose }: ContextMenuProps) {
+  return (
+    <>
+      <button
+        type="button"
+        aria-label="Cerrar menu contextual"
+        className="fixed inset-0 z-40 cursor-default bg-transparent"
+        onClick={onClose}
+      />
+      <div
+        className="fixed z-50 min-w-56 rounded-md border border-zinc-700 bg-zinc-900 p-1 text-sm text-zinc-100 shadow-2xl"
+        style={{ left: x, top: y }}
+        role="menu"
+      >
+        {actions.map((action) => (
+          <button
+            key={action.id}
+            type="button"
+            role="menuitem"
+            className={
+              action.danger
+                ? 'block w-full rounded px-3 py-2 text-left text-red-300 hover:bg-red-950/40'
+                : 'block w-full rounded px-3 py-2 text-left hover:bg-zinc-800'
+            }
+            onClick={() => {
+              action.onSelect()
+              onClose()
+            }}
+          >
+            {action.label}
+          </button>
+        ))}
+      </div>
+    </>
+  )
+}

--- a/apps/ui/src/pages/ProjectBoard.tsx
+++ b/apps/ui/src/pages/ProjectBoard.tsx
@@ -7,19 +7,29 @@ import {
   MiniMap,
   ReactFlow,
   ReactFlowProvider,
+  useReactFlow,
   useEdgesState,
   useNodesState,
   type Edge,
+  type NodeMouseHandler,
   type Node,
+  type PaneMouseHandler,
 } from '@xyflow/react'
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, Navigate, useParams } from 'react-router-dom'
 import { toast } from 'sonner'
 import { fetchCanvas, fetchProject, saveCanvas } from '../api/sentinelClient'
 import { buildDefaultNodes } from '../canvas/buildDefaultNodes'
 import { nodeTypes } from '../canvas/nodeTypes'
+import { ContextMenu, type ContextMenuAction } from '../components/ContextMenu'
+
+type ContextMenuState =
+  | { type: 'pane'; x: number; y: number }
+  | { type: 'node'; x: number; y: number; nodeId: string }
+  | null
 
 function ProjectCanvas({ projectId }: { projectId: string }) {
+  const flow = useReactFlow()
   const { data: project, isLoading: loadingProject } = useQuery({
     queryKey: ['project', projectId],
     queryFn: () => fetchProject(projectId),
@@ -33,8 +43,10 @@ function ProjectCanvas({ projectId }: { projectId: string }) {
 
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([])
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([])
+  const [contextMenu, setContextMenu] = useState<ContextMenuState>(null)
   const initialized = useRef(false)
   const skipNextSave = useRef(true)
+  const importInputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     initialized.current = false
@@ -113,6 +125,114 @@ function ProjectCanvas({ projectId }: { projectId: string }) {
     [setEdges, setNodes],
   )
 
+  const closeContextMenu = useCallback(() => setContextMenu(null), [])
+
+  useEffect(() => {
+    const onEsc = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setContextMenu(null)
+      }
+    }
+    window.addEventListener('keydown', onEsc)
+    return () => window.removeEventListener('keydown', onEsc)
+  }, [])
+
+  const onPaneContextMenu = useCallback<PaneMouseHandler>(
+    (event) => {
+      event.preventDefault()
+      setContextMenu({ type: 'pane', x: event.clientX, y: event.clientY })
+    },
+    [setContextMenu],
+  )
+
+  const onNodeContextMenu = useCallback<NodeMouseHandler<Node>>(
+    (event, node) => {
+      event.preventDefault()
+      setContextMenu({
+        type: 'node',
+        nodeId: node.id,
+        x: event.clientX,
+        y: event.clientY,
+      })
+    },
+    [setContextMenu],
+  )
+
+  const contextMenuActions = useMemo<ContextMenuAction[]>(() => {
+    if (!contextMenu) {
+      return []
+    }
+    if (contextMenu.type === 'pane') {
+      return [
+        {
+          id: 'import-repository',
+          label: '+ Importar repositorio (proximamente)',
+          onSelect: () => toast.message('Este flujo se implementa en la siguiente iteracion'),
+        },
+        {
+          id: 'add-widget',
+          label: '+ Anadir widget (proximamente)',
+          onSelect: () => toast.message('Los shortcuts de widgets llegan en el siguiente PR'),
+        },
+        {
+          id: 'fit-view',
+          label: 'Ajustar vista',
+          onSelect: () => flow.fitView({ duration: 250 }),
+        },
+        {
+          id: 'export-canvas',
+          label: 'Exportar canvas',
+          onSelect: exportLayout,
+        },
+        {
+          id: 'import-canvas',
+          label: 'Importar canvas',
+          onSelect: () => importInputRef.current?.click(),
+        },
+      ]
+    }
+
+    return [
+      {
+        id: 'open-settings',
+        label: 'Abrir configuracion (proximamente)',
+        onSelect: () => toast.message('El panel lateral de proyecto llega en siguiente iteracion'),
+      },
+      {
+        id: 'duplicate-node',
+        label: 'Duplicar tarjeta',
+        onSelect: () => {
+          setNodes((current) => {
+            const source = current.find((node) => node.id === contextMenu.nodeId)
+            if (!source) {
+              return current
+            }
+            const duplicate: Node = {
+              ...source,
+              id: crypto.randomUUID(),
+              position: { x: source.position.x + 40, y: source.position.y + 40 },
+              selected: false,
+            }
+            return [...current, duplicate]
+          })
+        },
+      },
+      {
+        id: 'delete-node',
+        label: 'Eliminar del canvas',
+        danger: true,
+        onSelect: () => {
+          setNodes((current) => current.filter((node) => node.id !== contextMenu.nodeId))
+          setEdges((current) =>
+            current.filter(
+              (edge) => edge.source !== contextMenu.nodeId && edge.target !== contextMenu.nodeId,
+            ),
+          )
+        },
+      },
+    ]
+  }, [contextMenu, exportLayout, flow, setEdges, setNodes])
+
   if (loadingProject || !project) {
     return (
       <div className="flex min-h-[50vh] items-center justify-center text-zinc-400">
@@ -142,6 +262,7 @@ function ProjectCanvas({ projectId }: { projectId: string }) {
           <label className="cursor-pointer rounded border border-zinc-700 px-3 py-1 text-xs hover:bg-zinc-900">
             Importar
             <input
+              ref={importInputRef}
               type="file"
               accept="application/json"
               className="hidden"
@@ -164,12 +285,22 @@ function ProjectCanvas({ projectId }: { projectId: string }) {
           nodeTypes={nodeTypes}
           onNodesChange={onNodesChange}
           onEdgesChange={onEdgesChange}
+          onPaneContextMenu={onPaneContextMenu}
+          onNodeContextMenu={onNodeContextMenu}
           fitView
         >
           <Background gap={20} size={1} variant={BackgroundVariant.Dots} />
           <Controls />
           <MiniMap />
         </ReactFlow>
+        {contextMenu ? (
+          <ContextMenu
+            x={contextMenu.x}
+            y={contextMenu.y}
+            actions={contextMenuActions}
+            onClose={closeContextMenu}
+          />
+        ) : null}
       </div>
     </>
   )


### PR DESCRIPTION
## Summary
- Add a contextual menu component for the board UI.
- Wire right-click interactions in `ProjectBoard` for pane/node actions.
- Include quality-of-life canvas actions (fit view, export/import, duplicate/delete node) with placeholders for upcoming board v2 flows.

## Test plan
- [ ] Run `pnpm --filter @sentinel/ui build`.
- [ ] Open a project board and verify right-click on pane opens custom menu.
- [ ] Right-click a node and validate duplicate/delete actions behave correctly.
- [ ] Verify context menu closes on outside click and `Escape`.