### PR TITLE
feat(ui): add project side panel tabs

### DIFF
--- a/apps/ui/src/components/ProjectPanel.tsx
+++ b/apps/ui/src/components/ProjectPanel.tsx
@@ -1,0 +1,269 @@
+import type { Project } from '@sentinel/shared-types'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useEffect, useMemo, useState } from 'react'
+import { toast } from 'sonner'
+import {
+  deployProject,
+  dockerAction,
+  fetchDeployments,
+  fetchEnv,
+  fetchSystemStats,
+  rollbackProject,
+  saveEnv,
+} from '../api/sentinelClient'
+
+export type ProjectPanelTab = 'deployments' | 'variables' | 'metrics' | 'settings'
+
+const tabs: Array<{ id: ProjectPanelTab; label: string }> = [
+  { id: 'deployments', label: 'Deployments' },
+  { id: 'variables', label: 'Variables' },
+  { id: 'metrics', label: 'Metrics' },
+  { id: 'settings', label: 'Settings' },
+]
+
+type ProjectPanelProps = {
+  project: Project
+  open: boolean
+  activeTab: ProjectPanelTab
+  onChangeTab: (tab: ProjectPanelTab) => void
+  onClose: () => void
+}
+
+export function ProjectPanel({ project, open, activeTab, onChangeTab, onClose }: ProjectPanelProps) {
+  const qc = useQueryClient()
+  const [envDraft, setEnvDraft] = useState<string | null>(null)
+
+  const { data: deployments = [], isLoading: loadingDeployments } = useQuery({
+    queryKey: ['deployments', project.id],
+    queryFn: () => fetchDeployments(project.id),
+    enabled: open && activeTab === 'deployments',
+    staleTime: 15_000,
+  })
+
+  const { data: envData } = useQuery({
+    queryKey: ['project-env', project.id],
+    queryFn: () => fetchEnv(project.id),
+    enabled: open && activeTab === 'variables',
+  })
+
+  const { data: stats } = useQuery({
+    queryKey: ['system-stats'],
+    queryFn: fetchSystemStats,
+    enabled: open && activeTab === 'metrics',
+    refetchInterval: 10_000,
+  })
+
+  const deployMutation = useMutation({
+    mutationFn: (pull: boolean) => deployProject(project.id, { pull }),
+    onSuccess: () => {
+      toast.success('Deploy lanzado')
+      void qc.invalidateQueries({ queryKey: ['project', project.id] })
+      void qc.invalidateQueries({ queryKey: ['deployments', project.id] })
+    },
+    onError: (error: Error) => toast.error(error.message),
+  })
+
+  const stopMutation = useMutation({
+    mutationFn: () => dockerAction(project.id, 'stop'),
+    onSuccess: () => {
+      toast.success('Servicios detenidos')
+      void qc.invalidateQueries({ queryKey: ['project', project.id] })
+    },
+    onError: (error: Error) => toast.error(error.message),
+  })
+
+  const rollbackMutation = useMutation({
+    mutationFn: (deploymentId: string) => rollbackProject(project.id, deploymentId),
+    onSuccess: () => {
+      toast.success('Rollback ejecutado')
+      void qc.invalidateQueries({ queryKey: ['project', project.id] })
+      void qc.invalidateQueries({ queryKey: ['deployments', project.id] })
+    },
+    onError: (error: Error) => toast.error(error.message),
+  })
+
+  const saveEnvMutation = useMutation({
+    mutationFn: (content: string) => saveEnv(project.id, content),
+    onSuccess: () => {
+      toast.success('.env guardado')
+      void qc.invalidateQueries({ queryKey: ['project-env', project.id] })
+    },
+    onError: (error: Error) => toast.error(error.message),
+  })
+
+  const latestSuccessfulDeployment = useMemo(
+    () => deployments.find((item) => item.status === 'success' || item.status === 'rolled_back'),
+    [deployments],
+  )
+
+  useEffect(() => {
+    setEnvDraft(null)
+  }, [project.id, activeTab])
+
+  const envContent = envDraft ?? envData?.content ?? ''
+
+  return (
+    <aside
+      className={
+        open
+          ? 'pointer-events-auto fixed inset-y-4 right-4 z-40 flex w-[420px] max-w-[92vw] flex-col rounded-xl border border-zinc-700 bg-zinc-900/95 shadow-2xl transition-all duration-150'
+          : 'pointer-events-none fixed inset-y-4 right-0 z-40 flex w-[420px] max-w-[92vw] translate-x-[105%] flex-col rounded-xl border border-zinc-700 bg-zinc-900/95 opacity-0 shadow-2xl transition-all duration-150'
+      }
+      aria-hidden={!open}
+    >
+      <header className="flex items-center justify-between border-b border-zinc-800 px-4 py-3">
+        <div>
+          <p className="text-sm text-zinc-500">Proyecto</p>
+          <h2 className="text-base font-semibold text-zinc-100">{project.name}</h2>
+        </div>
+        <button
+          type="button"
+          className="rounded border border-zinc-700 px-2 py-1 text-xs hover:bg-zinc-800"
+          onClick={onClose}
+        >
+          Cerrar
+        </button>
+      </header>
+
+      <div className="flex gap-1 border-b border-zinc-800 px-2 py-2">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            className={
+              activeTab === tab.id
+                ? 'rounded bg-violet-600 px-3 py-1.5 text-xs font-medium text-white'
+                : 'rounded px-3 py-1.5 text-xs text-zinc-300 hover:bg-zinc-800'
+            }
+            onClick={() => onChangeTab(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex-1 overflow-auto p-4 text-sm text-zinc-300">
+        {activeTab === 'deployments' ? (
+          <div className="space-y-3">
+            <p className="text-zinc-400">Estado actual: {project.status}</p>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                disabled={deployMutation.isPending}
+                className="rounded bg-emerald-600 px-3 py-1.5 text-xs text-white hover:bg-emerald-500 disabled:opacity-50"
+                onClick={() => deployMutation.mutate(false)}
+              >
+                Deploy
+              </button>
+              <button
+                type="button"
+                disabled={deployMutation.isPending}
+                className="rounded bg-zinc-700 px-3 py-1.5 text-xs text-white hover:bg-zinc-600 disabled:opacity-50"
+                onClick={() => deployMutation.mutate(true)}
+              >
+                Pull + deploy
+              </button>
+              <button
+                type="button"
+                disabled={stopMutation.isPending}
+                className="rounded bg-red-700 px-3 py-1.5 text-xs text-white hover:bg-red-600 disabled:opacity-50"
+                onClick={() => stopMutation.mutate()}
+              >
+                Stop
+              </button>
+            </div>
+            {latestSuccessfulDeployment ? (
+              <button
+                type="button"
+                className="rounded border border-zinc-700 px-3 py-1.5 text-xs hover:bg-zinc-800"
+                disabled={rollbackMutation.isPending}
+                onClick={() => rollbackMutation.mutate(latestSuccessfulDeployment.id)}
+              >
+                Rollback a {latestSuccessfulDeployment.commitSha.slice(0, 7)}
+              </button>
+            ) : null}
+
+            {loadingDeployments ? <p className="text-xs text-zinc-500">Cargando deployments...</p> : null}
+            <ul className="space-y-2 text-xs">
+              {deployments.slice(0, 8).map((dep) => (
+                <li key={dep.id} className="rounded border border-zinc-800 bg-zinc-950/70 p-2">
+                  <p className="font-medium text-zinc-200">
+                    {dep.status.toUpperCase()} · {dep.commitSha.slice(0, 7)}
+                  </p>
+                  <p className="text-zinc-500">{dep.commitMessage || 'Sin mensaje de commit'}</p>
+                </li>
+              ))}
+              {deployments.length === 0 ? (
+                <li className="text-zinc-500">No hay deployments registrados.</li>
+              ) : null}
+            </ul>
+          </div>
+        ) : null}
+
+        {activeTab === 'variables' ? (
+          <div className="space-y-3">
+            <p>Gestion de variables de entorno del proyecto.</p>
+            <textarea
+              className="min-h-40 w-full rounded border border-zinc-700 bg-zinc-950 p-2 text-xs text-zinc-200"
+              placeholder="Contenido de .env"
+              value={envContent}
+              onChange={(event) => setEnvDraft(event.target.value)}
+            />
+            <button
+              type="button"
+              className="rounded bg-violet-600 px-3 py-1.5 text-xs text-white hover:bg-violet-500 disabled:opacity-50"
+              disabled={saveEnvMutation.isPending}
+              onClick={() => saveEnvMutation.mutate(envContent)}
+            >
+              Guardar .env
+            </button>
+          </div>
+        ) : null}
+
+        {activeTab === 'metrics' ? (
+          <div className="space-y-3">
+            <p>Vista de metricas del host y endpoints custom.</p>
+            <div className="rounded border border-zinc-800 bg-zinc-950/70 p-3 text-xs">
+              <p>CPU load: {formatMetricValue((stats as { cpu?: { load?: number } } | undefined)?.cpu?.load, '%')}</p>
+              <p>
+                RAM usada:{' '}
+                {formatBytes((stats as { mem?: { used?: number } } | undefined)?.mem?.used)} /{' '}
+                {formatBytes((stats as { mem?: { total?: number } } | undefined)?.mem?.total)}
+              </p>
+              <p>
+                Disco usado:{' '}
+                {formatBytes((stats as { disk?: { used?: number } } | undefined)?.disk?.used)} /{' '}
+                {formatBytes((stats as { disk?: { size?: number } } | undefined)?.disk?.size)}
+              </p>
+            </div>
+          </div>
+        ) : null}
+
+        {activeTab === 'settings' ? (
+          <div className="space-y-3">
+            <p>Repo: {project.githubUrl}</p>
+            <p>Rama: {project.branch}</p>
+            <div className="rounded border border-red-900/60 bg-red-950/20 p-3 text-xs text-red-300">
+              Zona Danger: eliminar proyecto y acciones avanzadas en siguiente iteracion.
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </aside>
+  )
+}
+
+function formatBytes(bytes?: number): string {
+  if (!bytes || Number.isNaN(bytes)) {
+    return 'n/a'
+  }
+  const gb = bytes / (1024 * 1024 * 1024)
+  return `${gb.toFixed(1)} GB`
+}
+
+function formatMetricValue(value?: number, suffix = ''): string {
+  if (value === undefined || Number.isNaN(value)) {
+    return 'n/a'
+  }
+  return `${value.toFixed(1)}${suffix}`
+}

--- a/apps/ui/src/pages/ProjectBoard.tsx
+++ b/apps/ui/src/pages/ProjectBoard.tsx
@@ -22,6 +22,7 @@ import { fetchCanvas, fetchProject, saveCanvas } from '../api/sentinelClient'
 import { buildDefaultNodes } from '../canvas/buildDefaultNodes'
 import { nodeTypes } from '../canvas/nodeTypes'
 import { ContextMenu, type ContextMenuAction } from '../components/ContextMenu'
+import { ProjectPanel, type ProjectPanelTab } from '../components/ProjectPanel'
 
 type ContextMenuState =
   | { type: 'pane'; x: number; y: number }
@@ -44,6 +45,8 @@ function ProjectCanvas({ projectId }: { projectId: string }) {
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([])
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([])
   const [contextMenu, setContextMenu] = useState<ContextMenuState>(null)
+  const [isPanelOpen, setIsPanelOpen] = useState(false)
+  const [activePanelTab, setActivePanelTab] = useState<ProjectPanelTab>('deployments')
   const initialized = useRef(false)
   const skipNextSave = useRef(true)
   const importInputRef = useRef<HTMLInputElement>(null)
@@ -194,9 +197,36 @@ function ProjectCanvas({ projectId }: { projectId: string }) {
 
     return [
       {
+        id: 'open-deployments',
+        label: 'Ver deployments',
+        onSelect: () => {
+          setActivePanelTab('deployments')
+          setIsPanelOpen(true)
+        },
+      },
+      {
+        id: 'open-variables',
+        label: 'Ver variables',
+        onSelect: () => {
+          setActivePanelTab('variables')
+          setIsPanelOpen(true)
+        },
+      },
+      {
+        id: 'open-metrics',
+        label: 'Ver metricas',
+        onSelect: () => {
+          setActivePanelTab('metrics')
+          setIsPanelOpen(true)
+        },
+      },
+      {
         id: 'open-settings',
-        label: 'Abrir configuracion (proximamente)',
-        onSelect: () => toast.message('El panel lateral de proyecto llega en siguiente iteracion'),
+        label: 'Abrir configuracion',
+        onSelect: () => {
+          setActivePanelTab('settings')
+          setIsPanelOpen(true)
+        },
       },
       {
         id: 'duplicate-node',
@@ -254,6 +284,16 @@ function ProjectCanvas({ projectId }: { projectId: string }) {
         <div className="flex flex-wrap gap-2">
           <button
             type="button"
+            className="rounded border border-violet-700 px-3 py-1 text-xs text-violet-200 hover:bg-violet-950/40"
+            onClick={() => {
+              setActivePanelTab('deployments')
+              setIsPanelOpen(true)
+            }}
+          >
+            Abrir panel
+          </button>
+          <button
+            type="button"
             className="rounded border border-zinc-700 px-3 py-1 text-xs hover:bg-zinc-900"
             onClick={exportLayout}
           >
@@ -301,6 +341,13 @@ function ProjectCanvas({ projectId }: { projectId: string }) {
             onClose={closeContextMenu}
           />
         ) : null}
+        <ProjectPanel
+          project={project}
+          open={isPanelOpen}
+          activeTab={activePanelTab}
+          onChangeTab={setActivePanelTab}
+          onClose={() => setIsPanelOpen(false)}
+        />
       </div>
     </>
   )


### PR DESCRIPTION
## Summary
- Add a new right-side `ProjectPanel` with tabbed navigation for Deployments, Variables, Metrics, and Settings.
- Integrate panel opening from `ProjectBoard` and contextual node actions.
- Connect panel actions to existing Sentinel API endpoints for deploy, stop, rollback, env read/write, and system metrics.

## Test plan
- [x] Run `pnpm --filter @sentinel/ui build`.
- [ ] Open a project board and verify panel open/close behavior.
- [ ] Validate Deployments actions (`Deploy`, `Pull + deploy`, `Stop`, rollback button when available).
- [ ] Validate Variables tab can load and save `.env`.
- [ ] Validate Metrics tab refreshes host metrics periodically.