### PR TITLE
feat: add homelab CD workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy to homelab
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  deploy:
+    runs-on: self-hosted
+    timeout-minutes: 15
+
+    steps:
+      - name: Pull latest changes
+        run: |
+          cd /home/ihabfa/dev/Sentinel
+          git fetch origin develop
+          git reset --hard origin/develop
+
+      - name: Build and deploy
+        run: |
+          cd /home/ihabfa/dev/Sentinel
+          docker compose down
+          docker compose up -d --build
+
+      - name: Verify
+        run: |
+          sleep 10
+          cd /home/ihabfa/dev/Sentinel
+          docker compose ps

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
         VITE_API_URL: ${VITE_API_URL:-}
         VITE_API_KEY: ${SENTINEL_API_KEY:-cambia_esto}
     ports:
-      - "${SENTINEL_UI_PORT:-4000}:80"
+      - "${SENTINEL_UI_PORT:-4001}:80"
     depends_on:
       - sentinel-api
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to deploy on pushes to `develop` using a self-hosted runner.
- Add deploy steps to sync repository, rebuild containers, and verify services.
- Change default UI port mapping to `4001` to avoid host port 4000 conflicts.

## Test plan
- [ ] Push to `develop` and confirm workflow starts on self-hosted runner.
- [ ] Verify `docker compose up -d --build` completes successfully.
- [ ] Confirm UI is reachable on port 4001.